### PR TITLE
Fix conda environment and simplify installation and setup through git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 __pycache__/
 .idea
-/tools/CRISPRcasIdentifier/CRISPRcasIdentifier/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tools/CRISPRcasIdentifier/CRISPRcasIdentifier"]
+	path = tools/CRISPRcasIdentifier/CRISPRcasIdentifier
+	url = https://github.com/BackofenLab/CRISPRcasIdentifier.git
+	branch = v1.1.0

--- a/README.md
+++ b/README.md
@@ -13,83 +13,53 @@ approach not only provides the user with the basic statistics on the identified 
 but also produces a certainty score as an intuitive measure of the likelihood that a given
 genomic region is a CRISPR array.
 
-## Getting Started
+## Setup
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. 
+1. **Clone the repository** with submodules:
 
-### Prerequisites
+   ```
+   git clone --recurse-submodules https://github.com/BackofenLab/CRISPRidentify.git
+   ```
 
-First you need to install Miniconda
-Then create an environment and install the required libraries in it
+   Or alternatively, if already cloned, run:
 
+   ```
+   git submodule update --init --recursive
+   ```
 
-### Creating a Miniconda environment 
+   This ensures CRISPRcasIdentifier v1.1.0 is included at `tools/CRISPRcasIdentifier/` (so that the final path is `tools/CRISPRcasIdentifier/CRISPRcasIdentifier/CRISPRcasIdentifier.py`). If you want to setup the tool separately, you can also download it from [here](https://github.com/BackofenLab/CRISPRcasIdentifier) and place it in the correct location yourself.
 
-First we install Miniconda for python 3.
-Miniconda can be downloaded from here:
+2. **Install conda/mamba** (if not already):
+   - Either Conda (e.g. [Miniconda](https://docs.conda.io/en/latest/miniconda.html)) or Mamba (e.g. [micromamba](https://mamba.readthedocs.io/en/latest/installation.html)) is fine. We recommend micromamba for faster installation.
 
-https://docs.conda.io/en/latest/miniconda.html 
+3. **Create and activate the environment**:
 
-Then Miniconda should be installed. On a linux machine the command is similar to this one: 
+   With [conda](https://docs.conda.io/en/latest/miniconda.html):
+   ```
+   conda env create -f environment.yml
+   conda activate crispr_identify_env
+   ```
 
-```
-bash Miniconda3-latest-Linux-x86_64.sh
-```
+   Or with [micromamba](https://mamba.readthedocs.io/en/latest/installation.html):
 
-Then we create an environment. The necessary setup is provided in the "environment.yml" file.
+   ```
+   mamba env create -f environment.yml
+   mamba activate crispr_identify_env
+   ```
+   <sub><sub>We want to acknowledge Richard Stöckl @richardstoeckl for his contribution to the environment.yml file.</sub></sub>
 
-In order to install the corresponding environment one can execute the following command.
+4. **Download the models**:
 
-```
-conda env create -f environment.yml
-```
+   CRISPRcasIdentifier requires pretrained models. Due to GitHub's file size constraints, the authors made their HMM and ML models available in Google Drive. You can download and prepare them via the commands below (the necessary tools are installed in the crispr_identify_env for you), or by downloading them manually from [here](https://drive.google.com/file/d/1YbTxkn9KuJP2D7U1-6kL1Yimu_4RqSl1/view?usp=sharing) and [here](https://drive.google.com/file/d/1Nc5o6QVB6QxMxpQjmLQcbwQwkRLk-thM/view?usp=sharing). Save the model files inside CRISPRcasIdentifier's directory.
 
-We recommend to install mamba package manager which is a faster alternative to conda.
-
-```
-conda install -c conda-forge mamba
-```
-
-Then we can create the environment using mamba.
-```
-mamba env create -f environment.yml
-```
-
-<sub><sub>We want to acknowledge Richard Stöckl @richardstoeckl for his contribution to the environment.yml file.</sub></sub>
-
-
-### Additional preparations
-
-CRISPRidentify utilizes CRISPRcasIdentifier for the detection of the cas genes.
-If you are interested in cas gene result please install CRISPRcasIdentifier.
-
-Please make sure that after you downloaded CRISPRcasIdentifier its relative path is:
-
-```
-tools/CRISPRcasIdentifier/CRISPRcasIdentifier/CRISPRcasIdentifier.py
-```
-
-You can find the CRISPRcasIdentifier tool and its description [here](https://github.com/BackofenLab/CRISPRcasIdentifier)
-
-You need to make two steps:
-
-Firstly, you need to download the CRISPRcasIdentifier tool:
-```
-wget https://github.com/BackofenLab/CRISPRcasIdentifier/archive/v1.1.0.tar.gz
-tar -xzf v1.1.0.tar.gz
-```
-Secondly, you need to download the models:
-
-Due to GitHub's file size constraints, authors made their HMM and ML models available in Google Drive. You can download them [here](https://drive.google.com/file/d/1YbTxkn9KuJP2D7U1-6kL1Yimu_4RqSl1/view?usp=sharing) and [here](https://drive.google.com/file/d/1Nc5o6QVB6QxMxpQjmLQcbwQwkRLk-thM/view?usp=sharing). Save both tar.gz files inside CRISPRcasIdentifier's directory.
-
-
-### Activation of the environment
-
-Before running CRISPRidentify one need to activate the corresponding environment.
-
-```
-conda activate crispr_identify_env
-```
+   ```
+   # Download
+   gdown --fuzzy https://drive.google.com/file/d/1YbTxkn9KuJP2D7U1-6kL1Yimu_4RqSl1/view?usp=sharing
+   gdown --fuzzy https://drive.google.com/file/d/1Nc5o6QVB6QxMxpQjmLQcbwQwkRLk-thM/view?usp=sharing
+   # Extract
+   tar -xzf HMM_sets.tar.gz -C tools/CRISPRcasIdentifier/CRISPRcasIdentifier/
+   tar -xzf trained_models.tar.gz -C tools/CRISPRcasIdentifier/CRISPRcasIdentifier/
+   ```
 
 ## Running CRISPRidentify
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ genomic region is a CRISPR array.
 1. **Clone the repository** with submodules:
 
    ```
-   git clone --recurse-submodules https://github.com/BackofenLab/CRISPRidentify.git
+   git clone --recurse-submodules https://github.com/BackofenLab/CRISPRidentify.git && cd CRISPRidentify
    ```
 
    Or alternatively, if already cloned, run:
 
    ```
+   cd CRISPRidentify
    git submodule update --init --recursive
    ```
 
@@ -56,9 +57,8 @@ genomic region is a CRISPR array.
    # Download
    gdown --fuzzy https://drive.google.com/file/d/1YbTxkn9KuJP2D7U1-6kL1Yimu_4RqSl1/view?usp=sharing
    gdown --fuzzy https://drive.google.com/file/d/1Nc5o6QVB6QxMxpQjmLQcbwQwkRLk-thM/view?usp=sharing
-   # Extract
-   tar -xzf HMM_sets.tar.gz -C tools/CRISPRcasIdentifier/CRISPRcasIdentifier/
-   tar -xzf trained_models.tar.gz -C tools/CRISPRcasIdentifier/CRISPRcasIdentifier/
+   # Move the downloaded files to the correct location
+   mv *.tar.gz tools/CRISPRcasIdentifier/CRISPRcasIdentifier/
    ```
 
 ## Running CRISPRidentify

--- a/environment.yml
+++ b/environment.yml
@@ -49,5 +49,6 @@ dependencies:
   - keras==2.4.3
   - libffi=3.2.1
   - spacerplacer
+  - gdown
   - pip:
     - python-Levenshtein

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,6 @@ name: crispr_identify_env
 channels:
   - conda-forge
   - bioconda
-  - nodefaults
-  - biobuilds
-  - r
-  - axfeh
 dependencies:
   - python==3.7.6
   - pip
@@ -17,8 +13,8 @@ dependencies:
   - numpy==1.18.1
   - pandas=1.0.3
   - matplotlib=3.1.3
-  - perl=5.26.2
-  - perl-compress-bgzf=0.005
+  - perl>=5.26.2
+  - perl-compress-bgzf
   - perl-threaded=5.26.0
   - perl-yaml=1.29
   - prodigal==2.6.3
@@ -37,18 +33,16 @@ dependencies:
   - pyyaml=5.3.1
   - scikit-learn==0.22.1
   - scipy=1.4.1
-  - anaconda::tensorflow==2.3.0
-  - tensorboard==2.3.0
-  - tensorboard-plugin-wit==1.6.0
   - viennarna==2.4.15
   - pyopenssl=22.0.0
   - certifi=2022.12.7
   - vmatch==2.3.0
   - clustalo==1.2.3
   - blast==2.5.0
-  - keras==2.4.3
   - libffi=3.2.1
-  - spacerplacer
-  - gdown
+  - conda-forge::gdown
   - pip:
     - python-Levenshtein
+    - tensorflow==2.3.0
+    - keras==2.4.3
+    - tensorboard==2.3.0

--- a/tools/CRISPRcasIdentifier/README.txt
+++ b/tools/CRISPRcasIdentifier/README.txt
@@ -1,3 +1,0 @@
-link the CRISPRcasIdentifier folder here, such that you have a call like the following 
-
-CRISPRidentify/tools/CRISPRcasIdentifier/CRISPRcasIdentifier/CRISPRcasIdentifier.py


### PR DESCRIPTION
Hello, I hope you are doing well.

this PR does two things regarding the installation and setup process, therefore I didn't want to separate them into two PRs.

## 1. Fix and simplify the conda environment

Some dependencies and packages are not available in their specified version through the `conda-forge` or `bioconda` channels anymore (i.e. `tensorflow`). While some would still available through the `anaconda` channel, this has some restrictive licensing terms (see [the Anaconda Terms of Service](https://legal.anaconda.com/policies/en/)). Also, the environment file specified several channels that are either unnecessary (`axfeh`) or outdated (`biobuilds`).

Changes:
- Moved `tensorflow`, `tensorboard`, and `keras` to pip installation, keeping the same versions.
- Relaxed the Perl version constraint to allow the `perl-compress-bgzf` module build.
- Removed `axfeh::spacerplacer` (leftover from another project). If it is still needed, the `bioconda::spacerplacer` package should be used instead.
- Removed unnecessary channels


## 2. Automate `CRISPRcasIdentifier` setup

`CRISPRidentify` previously required users to manually download and place `CRISPRcasIdentifier v1.1.0` in the correct directory. Additionally, models had to be downloaded from Google Drive and placed in the correct location manually. This PR automates this process by adding `CRISPRcasIdentifier` as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules), and using `gdown` to download the correct models. The manual process remains possible without changes.

Changes:
- Introduces `BackofenLab/CRISPRcasIdentifier` as a git submodule pinned to `v1.1.0`. With `git clone --recurse-submodules`, the repository is now included automatically in the expected location.
- Adds `gdown` as a dependency and includes `README.md` commands to download the required models into the correct paths, following the procedure documented in `BackofenLab/CRISPRcasIdentifier`.

---
I cloned `CRISPRidentify` fresh with `--recurse-submodules` and followed the instructions using `gdown` for the model files. I then rebuilt the environment from scratch and confirmed that `python CRISPRidentify.py --input_folder TestInput` runs end-to-end.

I am open to feedback, and hope to see you soon again at another conference.

Best,
Richard